### PR TITLE
manifests: bump DPDK version to 20.11

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -15,7 +15,7 @@
   <project name="poky" revision="dunfell" remote="yocto" path="sources/poky"/>
   <project remote="oe" revision="dunfell" name="meta-openembedded" path="sources/meta-openembedded"/>
   <project remote="yocto" revision="dunfell" name="meta-virtualization" path="sources/meta-virtualization"/>
-  <project remote="yocto" revision="dunfell" name="meta-dpdk" path="sources/meta-dpdk"/>
+  <project remote="yocto" revision="fb2dd96868a3eb51673e4a1e122e0b375aa1832f" name="meta-dpdk" path="sources/meta-dpdk"/>
   <project remote="yocto" revision="dunfell" name="meta-intel" path="sources/meta-intel"/>
   <project remote="yocto" revision="dunfell" name="meta-security" path="sources/meta-security"/>
   <project remote="yocto" revision="dunfell" name="meta-selinux" path="sources/meta-selinux"/>


### PR DESCRIPTION
To follow the kernel and Open vSwtich update bump DPDK version to 20.11

Signed-off-by: Mathieu Dupré <mathieu.dupre@savoirfairelinux.com>

