### PR TITLE
kirkstone.xml: remove meta-elastic-beats

### DIFF
--- a/kirkstone.xml
+++ b/kirkstone.xml
@@ -29,7 +29,6 @@
   <!-- Other SEAPATH repositories -->
   <project name="vm_manager" revision="main" remote="seapath" path="sources/vm_manager"/>
   <project name="python3-setup-ovs" revision="main" remote="seapath" path="sources/python3-setup-ovs"/>
-  <project name="meta-elastic-beats" revision="main" remote="seapath" path="sources/meta-elastic-beats"/>
 
   <!-- Other community repositories -->
   <project name="Wind-River/meta-secure-core" revision="kirkstone" remote="github" path="sources/meta-secure-core"/>


### PR DESCRIPTION
The recipes of this meta are no longer used in meta-seapath.