### PR TITLE
sfl-kirkstone.xml: remove vm-manager and python3-setup-ovs

### DIFF
--- a/kirkstone.xml
+++ b/kirkstone.xml
@@ -26,10 +26,6 @@
   <!-- SEAPATH meta layers -->
   <project name="meta-seapath" revision="kirkstone" remote="seapath" path="sources/meta-seapath"/>
 
-  <!-- Other SEAPATH repositories -->
-  <project name="vm_manager" revision="main" remote="seapath" path="sources/vm_manager"/>
-  <project name="python3-setup-ovs" revision="main" remote="seapath" path="sources/python3-setup-ovs"/>
-
   <!-- Other community repositories -->
   <project name="Wind-River/meta-secure-core" revision="kirkstone" remote="github" path="sources/meta-secure-core"/>
   <project name="kraj/meta-clang" revision="kirkstone" remote="github" path="sources/meta-clang"/>


### PR DESCRIPTION
vm-manager and python3-setup-ovs are now fetched from git by their recipes in meta-seapath.
Remove them from the manifest.