### PR TITLE
README: Fix v1.0.0 repo init command

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,7 +35,7 @@ repo sync
 To checkout the v1.0.0 version:
 
 ```
-repo init -b v1.0.0 -u "https://github.com/seapath/repo-manifest.git"
+repo init -u "https://github.com/seapath/repo-manifest.git" -m v1.0.0.xml
 repo sync
 ```
 


### PR DESCRIPTION
The v1.0.0 is a tag and not a branch. The -b option only works with branches. The -m option is used to specify the manifest file to use.

