### PR TITLE
README: update the README to reflect the kirkstone version

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -25,10 +25,10 @@ repo init -u "https://github.com/seapath/repo-manifest.git"
 repo sync
 ```
 
-To checkout the dunfell version:
+To checkout the kirkstone version:
 
 ```
-repo init -u "https://github.com/seapath/repo-manifest.git" -m dunfell.xml
+repo init -u "https://github.com/seapath/repo-manifest.git" -m kirkstone.xml
 repo sync
 ```
 


### PR DESCRIPTION
The README was still mentioning the dunfell version which is EOL and the kirkstone version was not mentioned at all.