### PR TITLE
Wrynose migration

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -25,6 +25,14 @@ repo init -u "https://github.com/seapath/repo-manifest.git"
 repo sync
 ```
 
+To checkout the scarthgap version:
+
+```
+repo init -u "https://github.com/seapath/repo-manifest.git" -m scarthgap.xml
+repo sync
+```
+
+
 To checkout the kirkstone version:
 
 ```

--- a/default.xml
+++ b/default.xml
@@ -1,1 +1,1 @@
-scarthgap.xml
+wrynose.xml

--- a/wrynose.xml
+++ b/wrynose.xml
@@ -14,10 +14,10 @@
   <project name="yocto-bsp" revision="wrynose" remote="fork" path="."/>
 
   <!-- Upstream Yocto & OpenEmbedded Projects -->
-  <project name="bitbake" revision="2.18" remote="oe" path="sources/poky/bitbake"/>
-  <project name="meta-yocto" revision="wrynose" remote="yocto" path="sources/poky/meta-yocto"/>
-  <project name="openembedded-core" revision="wrynose" remote="oe" path="sources/poky"/>
-  <project name="wic" revision="master" remote="yocto" path="sources/poky/wic"/>
+  <project name="bitbake" revision="2.18" remote="oe" path="sources/bitbake"/>
+  <project name="meta-yocto" revision="wrynose" remote="yocto" path="sources/meta-yocto"/>
+  <project name="openembedded-core" revision="wrynose" remote="oe" path="sources/openembedded-core"/>
+
   <project remote="oe" revision="wrynose" name="meta-openembedded" path="sources/meta-openembedded"/>
   <project remote="yocto" revision="master" name="meta-virtualization" path="sources/meta-virtualization"/>
   <project remote="yocto" revision="master" name="meta-dpdk" path="sources/meta-dpdk"/>

--- a/wrynose.xml
+++ b/wrynose.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Copyright (C) 2020, RTE (http://www.rte-france.com) -->
-<!-- Copyright (C) 2023-2024 Savoir-faire Linux, Inc. -->
+<!-- Copyright (C) 2023-2026 Savoir-faire Linux, Inc. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 <manifest>
   <!-- Remote repositories definition -->

--- a/wrynose.xml
+++ b/wrynose.xml
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Copyright (C) 2020, RTE (http://www.rte-france.com) -->
+<!-- Copyright (C) 2023-2024 Savoir-faire Linux, Inc. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<manifest>
+  <!-- Remote repositories definition -->
+  <remote name="yocto" fetch="git://git.yoctoproject.org"/>
+  <remote name="github" fetch="https://github.com/"/>
+  <remote name="seapath" fetch="https://github.com/seapath"/>
+  <remote name="oe" fetch="git://git.openembedded.org"/>
+  <remote name="fork" fetch="https://github.com/paullgk"/>
+
+  <!-- SEAPATH main Yocto project -->
+  <project name="yocto-bsp" revision="wrynose" remote="fork" path="."/>
+
+  <!-- Upstream Yocto & OpenEmbedded Projects -->
+  <project name="bitbake" revision="2.18" remote="oe" path="sources/poky/bitbake"/>
+  <project name="meta-yocto" revision="wrynose" remote="yocto" path="sources/poky/meta-yocto"/>
+  <project name="openembedded-core" revision="wrynose" remote="oe" path="sources/poky"/>
+  <project name="wic" revision="master" remote="yocto" path="sources/poky/wic"/>
+  <project remote="oe" revision="wrynose" name="meta-openembedded" path="sources/meta-openembedded"/>
+  <project remote="yocto" revision="master" name="meta-virtualization" path="sources/meta-virtualization"/>
+  <project remote="yocto" revision="master" name="meta-dpdk" path="sources/meta-dpdk"/>
+  <project remote="yocto" revision="master" name="meta-intel" path="sources/meta-intel"/>
+  <project remote="yocto" revision="master" name="meta-security" path="sources/meta-security"/>
+  <project remote="yocto" revision="wrynose" name="meta-selinux" path="sources/meta-selinux"/>
+  <project remote="yocto" revision="master" name="meta-cgl" path="sources/meta-cgl"/>
+  <project remote="yocto" revision="master" name="meta-cloud-services" path="sources/meta-cloud-services"/>
+
+  <!-- SEAPATH meta layers -->
+  <project name="meta-seapath" revision="wrynose" remote="fork" path="sources/meta-seapath"/>
+
+  <!-- Other community repositories -->
+  <project name="agherzan/meta-raspberrypi" revision="master" remote="github" path="sources/meta-raspberrypi"/>
+  <project name="Wind-River/meta-secure-core" revision="wrynose" remote="github" path="sources/meta-secure-core"/>
+  <project name="kraj/meta-clang" revision="master" remote="github" path="sources/meta-clang"/>
+  <project name="sbabic/meta-swupdate" revision="wrynose" remote="github" path="sources/meta-swupdate"/>
+</manifest>


### PR DESCRIPTION
Hello,
This PR adds the needed modification to sync SEAPATH layers with Wrynose.
**Important notice:** As wrynose is still not released, the layers are currently sync on `master` branch.