### PR TITLE
wrynose: update manifest

### DIFF
--- a/wrynose.xml
+++ b/wrynose.xml
@@ -4,14 +4,13 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 <manifest>
   <!-- Remote repositories definition -->
-  <remote name="yocto" fetch="git://git.yoctoproject.org"/>
+  <remote name="yocto" fetch="https://git.yoctoproject.org"/>
   <remote name="github" fetch="https://github.com/"/>
   <remote name="seapath" fetch="https://github.com/seapath"/>
-  <remote name="oe" fetch="git://git.openembedded.org"/>
-  <remote name="fork" fetch="https://github.com/paullgk"/>
+  <remote name="oe" fetch="https://git.openembedded.org"/>
 
   <!-- SEAPATH main Yocto project -->
-  <project name="yocto-bsp" revision="wrynose" remote="fork" path="."/>
+  <project name="yocto-bsp" revision="wrynose" remote="seapath" path="."/>
 
   <!-- Upstream Yocto & OpenEmbedded Projects -->
   <project name="bitbake" revision="2.18" remote="oe" path="sources/bitbake"/>
@@ -19,20 +18,18 @@
   <project name="openembedded-core" revision="wrynose" remote="oe" path="sources/openembedded-core"/>
 
   <project remote="oe" revision="wrynose" name="meta-openembedded" path="sources/meta-openembedded"/>
-  <project remote="yocto" revision="master" name="meta-virtualization" path="sources/meta-virtualization"/>
-  <project remote="yocto" revision="master" name="meta-dpdk" path="sources/meta-dpdk"/>
-  <project remote="yocto" revision="master" name="meta-intel" path="sources/meta-intel"/>
-  <project remote="yocto" revision="master" name="meta-security" path="sources/meta-security"/>
+  <project remote="yocto" revision="wrynose" name="meta-virtualization" path="sources/meta-virtualization"/>
+  <project remote="yocto" revision="c4e58978ce61c47c2f54206e07f9ad46be2ed257" name="meta-dpdk" path="sources/meta-dpdk"/>
+  <project remote="yocto" revision="ff8ad78a0e3531060aa712b708cc01178c564a69" name="meta-intel" path="sources/meta-intel"/>
+  <project remote="yocto" revision="wrynose" name="meta-security" path="sources/meta-security"/>
   <project remote="yocto" revision="wrynose" name="meta-selinux" path="sources/meta-selinux"/>
-  <project remote="yocto" revision="master" name="meta-cgl" path="sources/meta-cgl"/>
-  <project remote="yocto" revision="master" name="meta-cloud-services" path="sources/meta-cloud-services"/>
+  <project remote="yocto" revision="efbec7502e8027d350c05997678c12aa35662f0e" name="meta-cgl" path="sources/meta-cgl"/>
+  <project remote="yocto" revision="wrynose" name="meta-cloud-services" path="sources/meta-cloud-services"/>
 
   <!-- SEAPATH meta layers -->
-  <project name="meta-seapath" revision="wrynose" remote="fork" path="sources/meta-seapath"/>
+  <project name="meta-seapath" revision="wrynose" remote="seapath" path="sources/meta-seapath"/>
 
   <!-- Other community repositories -->
-  <project name="agherzan/meta-raspberrypi" revision="master" remote="github" path="sources/meta-raspberrypi"/>
   <project name="Wind-River/meta-secure-core" revision="wrynose" remote="github" path="sources/meta-secure-core"/>
-  <project name="kraj/meta-clang" revision="master" remote="github" path="sources/meta-clang"/>
   <project name="sbabic/meta-swupdate" revision="wrynose" remote="github" path="sources/meta-swupdate"/>
 </manifest>


### PR DESCRIPTION
Changed master branch to wrynose branch when it is possible. When It is impossible use a fixed commit ID.

Use protocol https instead of git.

Remove no longer needed layers:
- meta-raspberrypi
- meta-clang

